### PR TITLE
allow kube to determine patch level

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ On OS X this is achieved by entering the following into your terminal, replacing
 |default_pool_size| No of workers in default pool | 3 |
 |private_vlan_id|The private vlan ID. Run ic ks vlans `datacenter` to retrieve vlans||
 |public_vlan_id|The public vlan ID.Run ic ks vlans `datacenter` to retrieve vlans||
-|kube_version|The desired Kubernetes version of the created cluster. Run ic ks kube-versions to get latest verions.|1.14.6|
+|kube_version|The desired Kubernetes version of the created cluster. Run ic ks kube-versions to get latest verions.|1.14|

--- a/variables.tf
+++ b/variables.tf
@@ -23,5 +23,5 @@ variable "cluster_name" {
 }
 variable kube_version {
   #default = "3.11.104_openshift"
-  default = "1.14.6"
+  default = "1.14"
 }


### PR DESCRIPTION
currently, with 1.14.6 as the default, the deploy will fail since 1.14.7 is the latest. Just remove the patch level and let kube figure it out